### PR TITLE
fix: setActionEventActive is called with one argument (:245)

### DIFF
--- a/scripts/EarlyUnloadHandler.lua
+++ b/scripts/EarlyUnloadHandler.lua
@@ -242,7 +242,7 @@ function EarlyUnloadHandler.onRegisterActionEvents(baler, superFunc, isActiveFor
 		local isValid, actionEventId = baler:addPoweredActionEvent(spec.actionEvents, 'UNLOAD_BALE_EARLY', baler, Baler.actionEventUnloading, false, true, false, true, nil)
 		if isValid then
 			g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_HIGH)
-			g_inputBinding:setActionEventActive(false)
+			g_inputBinding:setActionEventActive(actionEventId, false)
 			baler.unloadBaleActionEventId = actionEventId
 		else
 			Logging.warning("%s: Failed registering the action event for unloading early. Another action might be bound to the same key.", MOD_NAME)


### PR DESCRIPTION
`scripts/EarlyUnloadHandler.lua:245` calls `setActionEventActive` with one argument:

```lua
local isValid, actionEventId = baler:addPoweredActionEvent(spec.actionEvents, 'UNLOAD_BALE_EARLY', ...)  -- :242
if isValid then
    g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_HIGH)   -- :244
    g_inputBinding:setActionEventActive(false)                               -- :245
    baler.unloadBaleActionEventId = actionEventId                            -- :246
```

The signature is `setActionEventActive(actionEventId, isActive)`, so `false` is being passed as the **actionEventId** and `isActive` is missing entirely. The `actionEventId` obtained on `:242` never reaches the call, so the action event this line means to deactivate cannot be the one it affects.

You use the correct two-argument form 23 lines above at `:222` (`setActionEventActive(baler.unloadBaleActionEventId, showAction)`), and again in FS25_ToolInclinationHelper at `ToolReferenceOrientationHandler.lua:111`.

For what it's worth, I checked the base game's own usage rather than going by memory: **129 call sites, none of them with a single argument** — all of the form `setActionEventActive(actionEvent.actionEventId, <bool>)`, including the exact deactivation idiom `setActionEventActive(actionEvent.actionEventId, false)`.

## Impact — honest assessment

**Mostly masked.** `:253` calls `Baler.updateActionEvents(baler)` right afterwards, and `:222` then sets the state correctly, so in the normal path the intended deactivation is applied a moment later anyway. It only matters when `updateActionEvents` returns early at `:186` before reaching `:222` — then the event stays in its default state instead of being deactivated.

So: the defect itself is proven, the field symptom is situational. I'm not going to claim you have a visible bug here; I'd frame it as a latent one that's currently covered by the follow-up call.

## Verification

Read-only audit against `92b0fe2`. `luac -p` passes. Not reproduced in-game.

## Side note (not touched here)

`scripts/EarlyUnloadHandler.lua:60` passes a variable named `connection` as `ignoreConnection`:

```lua
g_server:broadcastEvent(OverrideBaleSizeEvent.new(baler, fillLevel), nil, connection, nil)
```

`connection` is neither a parameter nor a local of `scaleBaleToMax(baler, fillLevel)` — it appears exactly once in the whole file, on that line, so it reads as an undefined global and is always `nil`. That happens to be the value you want there, so nothing is broken today; it looks like a copy-paste from `UnloadBalesSettingsChangeEvent.lua:32`, where `connection` is a real parameter. Left it alone to keep this diff to one line, but it'll bite whenever some mod defines a global with that name.
